### PR TITLE
add ua aware css generation for chome mobile

### DIFF
--- a/lib/generate_css.js
+++ b/lib/generate_css.js
@@ -63,7 +63,8 @@ function supportsLocal(ua) {
       || ua.family === 'IE' && ((ua.major > 5)
                                   || (ua.major === 5 && ua.minor >= 5))
       || ua.family === 'Opera' && (ua.major >= 10)
-      || ua.family === 'Mobile Safari';
+      || ua.family === 'Mobile Safari'
+      || ua.family === 'Chrome Mobile';
 }
 
 function supportsWoff(ua) {
@@ -75,7 +76,8 @@ function supportsWoff(ua) {
                                   || (ua.major === 5 && ua.minor >= 1))
       || ua.family === 'IE' && (ua.major >= 9)
       || ua.family === 'Opera' && ((ua.major > 11)
-                                || (ua.major === 11 && ua.minor >= 10));
+                                || (ua.major === 11 && ua.minor >= 10))
+      || ua.family === 'Chrome Mobile';
 }
 
 function supportsEmbeddedOpentype(ua) {


### PR DESCRIPTION
this adds css generation support for chrome mobile. previous version did
not provide any format. i guess that chrome for android supports
truetype and svg as well, but as local and woff are supported and
preferred this change should be fine and for what it’s worth: the google
font webservice provides the same format options.
